### PR TITLE
add volunteer and info links, supplues needed to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,6 +174,13 @@
           For the latest updates, please see articles posted to our <a href="https://www.patreon.com/trianglemutualaid" target="_blank">Patreon Site</a>. 
           </p>
           
+          <p><strong>Volunteering</strong></p>
+          <a href="https://docs.google.com/spreadsheets/d/188WcEJoihTJ6jLtbqogHcasE9lYSsX_FCZgxYXqLOfE/edit?gid=0#gid=0">Volunteer Sign-Up Sheet</a><br>
+          <a href="https://docs.google.com/document/d/12NuGu-p4eCvfVbdlUJA6HkvTMEaYzvUtMXPtxCL6lTI/edit?usp=sharing">Warehouse Volunteering Instructions</a>
+          <p><strong>Supplies Needed</strong></p>
+          <p>Use scrollbar on the right to see complete list</p>
+          <iframe src="https://docs.google.com/document/d/e/2PACX-1vSdmVWgqYlqa1JT-CZmZ5bx7y-xZ0kstWNYFZvuFNms723ahXv122N4HwP_7MXj1GmjqWuGqF-8rt8k/pub?embedded=true"></iframe>
+
           <p>
           <strong>Drop-off Locations for Donations</strong>
           </p>


### PR DESCRIPTION
This pr adds links to google docs for volunteer sign up and info. This doc https://docs.google.com/document/d/1QobNy3RF4u_kgrAoUjPfLSpxdvbgc-iAGgb5fTcQIzg/edit?usp=sharing is embedded as an iFrame and needs to be updated with current supply needs.